### PR TITLE
UploadInterface 내부에서 thumnail객체를 public으로 오픈.

### DIFF
--- a/libs/ext/UploadInterface/UploadInterface.class.js
+++ b/libs/ext/UploadInterface/UploadInterface.class.js
@@ -11,8 +11,7 @@ var UploadInterface = function(el, options) {
 	this.$drop = null;
 	this.$controller = null;
 	this.readyItem = new Array();
-
-	var thumnail = new Thumnail(self, {
+	this.thumnail = new Thumnail(self, {
 		type : self.settings.thumnailType
 		,size : self.settings.thumnailSize.split('*')
 		,quality : 0.8
@@ -457,7 +456,7 @@ var UploadInterface = function(el, options) {
 		}
 		if (item)
 		{
-			thumnail.open(item);
+			self.thumnail.open(item);
 		}
 	}
 

--- a/plugins/article/imageSlide/js/UploadInterface.class.js
+++ b/plugins/article/imageSlide/js/UploadInterface.class.js
@@ -12,8 +12,7 @@ var UploadInterface = function(el, options) {
 	this.$controller = null;
 	this.json = new Object();
 	this.readyItem = new Array();
-
-	var thumnail = new Thumnail(self, {
+	this.thumnail = new Thumnail(self, {
 		type : self.settings.thumnailType
 		,size : self.settings.thumnailSize.split('*')
 		,quality : 0.8
@@ -412,7 +411,7 @@ var UploadInterface = function(el, options) {
 		}
 		if (item)
 		{
-			thumnail.open(item);
+			self.thumnail.open(item);
 		}
 	}
 


### PR DESCRIPTION
이유는 동적으로 썸네일 이미지 사이즈를 조절 할 수 있게 하기 위하여 권한 변경
